### PR TITLE
Improve email search by adjusting tier 2 trigger condition

### DIFF
--- a/server/search/services/parallel-email-search.ts
+++ b/server/search/services/parallel-email-search.ts
@@ -197,8 +197,8 @@ export async function parallelTieredEmailSearch(
   
   console.log(`[Parallel Search] Tier 1 complete in ${Date.now() - tier1StartTime}ms - Found ${emailsFoundInTier1} new emails`);
   
-  // TIER 2: Only if less than 1 email found in Tier 1
-  if (emailsFoundInTier1 < 1 && topContacts.length > 0) {
+  // TIER 2: Only if less than 2 emails found in Tier 1
+  if (emailsFoundInTier1 < 2 && topContacts.length > 0) {
     console.log(`[Parallel Search] === TIER 2: Perplexity + Hunter (conditional) ===`);
     const tier2StartTime = Date.now();
     


### PR DESCRIPTION
Adjusted the condition for initiating Tier 2 email search from less than 1 to less than 2 emails found in Tier 1 within `parallel-email-search.ts`.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 13fd088a-3ef5-44d9-9d8b-c4f98609e222
Replit-Commit-Checkpoint-Type: full_checkpoint